### PR TITLE
Added a custom exception and crypto info prints

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/EncryptionStrategy.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/EncryptionStrategy.java
@@ -38,20 +38,49 @@ public interface EncryptionStrategy {
    * @return true if initialization was successful
    * @since 2.0
    */
-  boolean init(Scope encryptionScope, AccumuloConfiguration configuration) throws Exception;
+  boolean init(Scope encryptionScope, AccumuloConfiguration configuration)
+      throws EncryptionStrategyException;
 
   /**
    * Encrypts the OutputStream.
    *
    * @since 2.0
    */
-  OutputStream encryptStream(OutputStream outputStream) throws Exception;
+  OutputStream encryptStream(OutputStream outputStream) throws EncryptionStrategyException;
 
   /**
    * Decrypts the InputStream.
    *
    * @since 2.0
    */
-  InputStream decryptStream(InputStream inputStream) throws Exception;
+  InputStream decryptStream(InputStream inputStream) throws EncryptionStrategyException;
 
+  /**
+   * This method is responsible for printing all information required for decrypting to a stream
+   *
+   * @param outputStream
+   *          The stream being written in requiring crypto information
+   * @throws EncryptionStrategyException
+   *           if the print fails
+   */
+  void printCryptoInfoToStream(OutputStream outputStream);
+
+  public class EncryptionStrategyException extends RuntimeException {
+    EncryptionStrategyException() {
+      super();
+    }
+
+    EncryptionStrategyException(String message) {
+      super(message);
+    }
+
+    EncryptionStrategyException(String message, Throwable cause) {
+      super(message, cause);
+    }
+
+    EncryptionStrategyException(Throwable cause) {
+      super(cause);
+    }
+
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/NoEncryptionStrategy.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/NoEncryptionStrategy.java
@@ -42,4 +42,9 @@ public class NoEncryptionStrategy implements EncryptionStrategy {
     // do nothing
     return inputStream;
   }
+
+  @Override
+  public void printCryptoInfoToStream(OutputStream outputStream) {
+    // do nothing
+  }
 }


### PR DESCRIPTION
Added a custom exception for the encryption strategy, which adds more clarity than throwing Exception or RuntimeException.

I also put in, but didn't implement, a method in the EncryptionStrategy interface for printing the crypto configurations. Files should be able to call this method and provide a file stream the strategy can write the necessary parameters to. Such parameters would include the algorithm/mode/padding, wrapped FEK, etc -- everything the strategy needs to decrypt the file later. Writing the parameters through this method keeps the individual file writers fully independent from details specific to any crypto strategy.