### PR TITLE
Code review feedback

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriterBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriterBuilder.java
@@ -111,6 +111,10 @@ class RFileWriterBuilder implements RFile.OutputArguments, RFile.WriterFSOptions
   @Override
   public WriterFSOptions to(String filename) {
     Objects.requireNonNull(filename);
+    if (!filename.endsWith(".rf")) {
+      throw new IllegalArgumentException(
+          "Provided filename (" + filename + ") does not end with '.rf'");
+    }
     this.out = new OutputArgs(filename);
     return this;
   }


### PR DESCRIPTION
Throw IllegalArgumentException early when a filename that does not end
in the appropriate RFile extension is used in the RFileWriterBuilder.